### PR TITLE
Convert readthedocs links for their .org -> .io migration for hosted projects

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -14,4 +14,4 @@ The implementation is heavily based on `Fast Mergeable Integer Maps <http://ittc
 by Okasaki and Gill, but it has been adapted to support a somewhat different feature
 set and a more compact representation for certain usage patterns.
 
-For usage, see the `API documentation <http://intset.readthedocs.org/en/latest/>`_.
+For usage, see the `API documentation <https://intset.readthedocs.io/en/latest/>`_.


### PR DESCRIPTION
As per [their blog post of the 27th April](https://blog.readthedocs.com/securing-subdomains/) ‘Securing subdomains’:

> Starting today, Read the Docs will start hosting projects from subdomains on the domain readthedocs.io, instead of on readthedocs.org. This change addresses some security concerns around site cookies while hosting user generated data on the same domain as our dashboard.

Test Plan: Manually visited all the links I’ve modified.
